### PR TITLE
Remove error log when URL param cannot be decoded

### DIFF
--- a/packages/web/src/components/basic/URLParamsProvider.js
+++ b/packages/web/src/components/basic/URLParamsProvider.js
@@ -31,7 +31,6 @@ class URLParamsProvider extends Component {
 					this.props.setValue(component, JSON.parse(value), label, showFilter, URLParams);
 				} catch (e) {
 					// Do not set value if JSON parsing fails.
-					console.error(e);
 				}
 			});
 		};


### PR DESCRIPTION
For scenarios where reactivesearch is part of a larger application that uses URL parameters that are not in JSON format we do not want to log errors since it is expected that some URL parameters will not belong to reactivesearch. See #955 for associated Vue issue that was resolved in a similar manner.


**Before submitting a pull request,** please make sure the following is done:

- [ ] Describe the proposed changes and how it'll improve the library experience.
- [ ] Please make sure that there is no linting errors in the code.
- [ ] Create a PR to add/update the docs (if needed) at [here](https://github.com/appbaseio/Docs).
- [ ] Create a PR to add/update the storybook (if needed) at [here](https://github.com/appbaseio/playground).

**Learn more about contributing:** [Contributing guides](https://github.com/appbaseio/reactivesearch/blob/next/.github/CONTRIBUTING.md)
